### PR TITLE
UIU-2179 refactor away from react-intl-safe-html

### DIFF
--- a/.github/workflows/build-npm-fork.yml
+++ b/.github/workflows/build-npm-fork.yml
@@ -21,7 +21,6 @@ on:
 
 jobs:
   build-npm-fork:
-    if: contains(github.event.pull_request.labels.*.name, 'safe fork')
     env:
       YARN_TEST_OPTIONS: '--ci --coverage --colors'
       SQ_ROOT_DIR: './src'

--- a/src/settings/patronBlocks/Conditions/Conditions.js
+++ b/src/settings/patronBlocks/Conditions/Conditions.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import { stripesConnect } from '@folio/stripes/core';
 import { Callout } from '@folio/stripes/components';
-import SafeHTMLMessage from '@folio/react-intl-safe-html';
+import FormattedMessage from 'react-intl';
 
 import ConditionsForm from './ConditionsForm';
 import css from '../patronBlocks.css';
@@ -60,7 +60,7 @@ class Conditions extends Component {
     }).then(() => {
       if (this.callout) {
         this.callout.current.sendCallout({
-          message: <SafeHTMLMessage
+          message: <FormattedMessage
             id="ui-users.settings.callout.message"
             values={{ name: value.name }}
           />

--- a/src/settings/patronBlocks/Limits/Limits.js
+++ b/src/settings/patronBlocks/Limits/Limits.js
@@ -12,7 +12,7 @@ import {
 
 import { stripesConnect } from '@folio/stripes/core';
 import { Callout } from '@folio/stripes/components';
-import SafeHTMLMessage from '@folio/react-intl-safe-html';
+import FormattedMessage from 'react-intl';
 
 import LimitsForm from './LimitsForm';
 
@@ -206,7 +206,7 @@ class Limits extends Component {
     const { patronGroup } = this.props;
     const limits = this.saveLimits(value);
     const showSuccessMessage = (
-      <SafeHTMLMessage
+      <FormattedMessage
         id="ui-users.settings.limits.callout.message"
         values={{ patronGroup }}
       />


### PR DESCRIPTION
Refactor away from `react-intl-safe-html` since its features
are now supported natively by `react-intl`.

Refs UIU-2179